### PR TITLE
fix regression to CSV output of elapsed time in micros

### DIFF
--- a/src/ipv4/icmp.rs
+++ b/src/ipv4/icmp.rs
@@ -113,6 +113,7 @@ pub(crate) fn ipv4_handle_icmp_echo_reply(
                 data_bytes,
                 &program_state.host_addr.ip(),
                 &remote_ip,
+                program_state.started,
                 original_instant,
                 icmp.sequence,
                 ip.ttl,

--- a/src/main.rs
+++ b/src/main.rs
@@ -412,7 +412,7 @@ impl IcmpProgramState {
         &self,
         host_ip: &IpAddr,
         remote_ip: &IpAddr,
-        instant_original: Option<Instant>,
+        instant_echo_request: Option<Instant>,
         sequence: u16,
         ttl: u8,
         error: String,
@@ -424,10 +424,10 @@ impl IcmpProgramState {
         match self.output {
             crate::cli::OutputMode::Default | crate::cli::OutputMode::Regular => {
                 // regular output //
-                match instant_original {
-                    Some(instant_original) => {
+                match instant_echo_request {
+                    Some(instant_echo_request) => {
                         let request_millis =
-                            (Instant::now() - instant_original).as_secs_f64() * 1000.0;
+                            (Instant::now() - instant_echo_request).as_secs_f64() * 1000.0;
                         println!(
                             "Reply from {}: icmp_seq={} ttl={}: {:.3} ms -- {}",
                             remote_ip, sequence, ttl, request_millis, error
@@ -451,7 +451,8 @@ impl IcmpProgramState {
         data_bytes: usize,
         host_ip: &IpAddr,
         remote_ip: &IpAddr,
-        instant_original: Instant,
+        instant_program_started: Instant,
+        instant_echo_request: Instant,
         sequence: u16,
         ttl: u8,
     ) {
@@ -462,7 +463,7 @@ impl IcmpProgramState {
         match self.output {
             crate::cli::OutputMode::Default | crate::cli::OutputMode::Regular => {
                 // regular output //
-                let request_millis = (Instant::now() - instant_original).as_secs_f64() * 1000.0;
+                let request_millis = (Instant::now() - instant_echo_request).as_secs_f64() * 1000.0;
                 println!(
                     "{} bytes from {}: icmp_seq={} ttl={}: {:.3} ms",
                     data_bytes, remote_ip, sequence, ttl, request_millis
@@ -470,7 +471,7 @@ impl IcmpProgramState {
             }
             crate::cli::OutputMode::CSV => {
                 // all errors are attributed to the host IP not the received IP //
-                self.output_csv(host_ip, Some(instant_original), sequence);
+                self.output_csv(host_ip, Some(instant_program_started), sequence);
             }
         }
     }


### PR DESCRIPTION
A regression was introduced by the refactor from commit 511a1f2 which changed CSV output time from micros elapsed since program start to micros of request round trip time.

This commit fixes the regression and makes the variables for the Instant's used in the output_csv and output_ping functions more clear what they're used for.

fixes #3